### PR TITLE
Always assign the "front face" identity of a collection proxy to the proxiedObject when faulting in after a refresh

### DIFF
--- a/ReStore/SSWDBObjectProxy.cls
+++ b/ReStore/SSWDBObjectProxy.cls
@@ -372,10 +372,12 @@ _unstore
 	collectionProxies do: [ :each | each _unstore]!
 
 _updateCollectionProxyUsing: aCollectionSpec
+	"Assign the correct collection proxy for <aCollectionSpec> to the proxied object. Return the collection proxy.
+	Note that we may actually assign the proxied collection itself, if the collection proxy is swapped--what is important
+	is that we assign the correct *identity* so everything works out."
 
-	"Return the collection proxy"
-
-	^aCollectionSpec accessor value: (collectionProxies at: aCollectionSpec) in: proxiedObject!
+	^aCollectionSpec accessor value: (collectionProxies at: aCollectionSpec) _frontFace
+		in: proxiedObject.!
 
 _valuesForAccessor: anInstVarAccessor
 

--- a/ReStore/SSWDBProxy.cls
+++ b/ReStore/SSWDBProxy.cls
@@ -174,6 +174,14 @@ _forgetProxiedObject
 	
 	proxiedObject := nil!
 
+_frontFace
+	"Private - Answer the 'front face' identity associated with the receiver--the identity that should be referenced by other persisted objects.
+	When the receiver is swapped, this is the proxiedObject.
+	
+	N.B. Must be called in a critical section."
+
+	^self _isSwapped ifTrue: [self _proxiedObject] ifFalse: [self].!
+
 _hasChanged
 
 	"Return whether the receiver's proxiedObject has been changed
@@ -722,6 +730,7 @@ _forceRefresh!actions-refresh!public! !
 _forceRefreshIn:!actions-refresh!public! !
 _forceRefreshWithContents!actions-refresh!public! !
 _forgetProxiedObject!actions-internal!public! !
+_frontFace!accessing!private! !
 _hasChanged!public!testing! !
 _hasChangedFrom:!public!testing! !
 _isDeleted!public!testing! !

--- a/ReStore/SSWReStoreRefreshTest.cls
+++ b/ReStore/SSWReStoreRefreshTest.cls
@@ -634,6 +634,27 @@ testRefreshWithOnRollback
 			removeSelector: #onRollback fromClass: OwnedTest;
 			removeSelector: #onRollback fromClass: OwnerTest]!
 
+testSwapCollectionProxyBeforeFaultInParentAfterRefresh
+	| owner coll |
+	owner := (OwnerTest storedInstancesIn: reStore) first.
+	coll := owner ownedOrdered.
+	"Sanity checks:"
+	self deny: owner isDBProxy.
+	self assert: coll isDBProxy.
+	"Must be a lazy refresh as a force refresh will link everything up before any proxies can be swapped"
+	reStore lazyRefresh: owner.
+	self assert: owner isDBProxy.
+	self deny: owner _isRecovered.
+	"Swap the collection proxy before triggering fault-in of the owner. In practice this can happen due to process contention, where the collection is on the stack of another process, rather than someone explicitly holding a reference to the collection."
+	coll first.
+	self deny: coll isDBProxy.
+	self assert: owner isDBProxy.
+	self deny: owner _isRecovered.
+	"Now trigger fault-in of the owner. If the 'back face' identity is mistakenly assigned this will fail"
+	self assert: coll identicalTo: owner ownedOrdered.
+	"Or, more practically, we should not get a 'Trying to swap already-swapped proxy' error here:"
+	self shouldnt: [owner ownedOrdered first] raise: Error.!
+
 usesVersioning
 
 	^true! !
@@ -659,6 +680,7 @@ testGeneralCollectionRefreshQueryCount!public!unit tests! !
 testOwnedCollectionRefreshQueryCount!public!unit tests! !
 testRefreshOfCopyObject!public!unit tests! !
 testRefreshWithOnRollback!public!unit tests! !
+testSwapCollectionProxyBeforeFaultInParentAfterRefresh!public!unit tests! !
 usesVersioning!public!running! !
 !
 


### PR DESCRIPTION
If the collection proxy is already swapped when the parent object is faulted in, we must assign what is at that point the proxied collection itself to the slot of the proxiedObject, otherwise we get a double-swap error when the swapped proxy gets another #doesNotUnderstand:.

I've had the terminology in my mind for a long time of calling the identity that the application interacts with the "front face", and the one that resides in the proxy cache the "back face". This seemed like a good opportunity, now that the `_isSwapped` flag exists, to expose this as a method, but with only the one usage, if you think it'd be better to just inline the test in `_updateCollectionProxyUsing:`, that'd be fine too.