### PR TITLE
Fix case of broken change detection for mutable fields (e.g. Bitmask)

### DIFF
--- a/ReStore/DetailedPerson.cls
+++ b/ReStore/DetailedPerson.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smallalk"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 SuperPerson subclass: #DetailedPerson
 	instanceVariableNames: 'dob dateOfBirth friend bestFriend'

--- a/ReStore/DetailedPerson1.cls
+++ b/ReStore/DetailedPerson1.cls
@@ -17,8 +17,10 @@ friend2
 
 friend2: anObject
 	friend2 := anObject! !
-!DetailedPerson1 categoriesFor: #friend2!accessing!private! !
-!DetailedPerson1 categoriesFor: #friend2:!accessing!private! !
+!DetailedPerson1 categoriesForMethods!
+friend2!accessing!private! !
+friend2:!accessing!private! !
+!
 
 !DetailedPerson1 class methodsFor!
 
@@ -27,5 +29,7 @@ reStoreDefinition
 	^super reStoreDefinition
 		define: #friend2 as: DetailedPerson2;
 		yourself! !
-!DetailedPerson1 class categoriesFor: #reStoreDefinition!public! !
+!DetailedPerson1 class categoriesForMethods!
+reStoreDefinition!public! !
+!
 

--- a/ReStore/DetailedPerson2.cls
+++ b/ReStore/DetailedPerson2.cls
@@ -41,16 +41,18 @@ notes
 
 notes: anObject
 	notes := anObject! !
-!DetailedPerson2 categoriesFor: #bestFriend!accessing!private! !
-!DetailedPerson2 categoriesFor: #bestFriend:!accessing!private! !
-!DetailedPerson2 categoriesFor: #dateOfBirth!accessing!private! !
-!DetailedPerson2 categoriesFor: #dateOfBirth:!accessing!private! !
-!DetailedPerson2 categoriesFor: #dob!accessing!private! !
-!DetailedPerson2 categoriesFor: #dob:!accessing!private! !
-!DetailedPerson2 categoriesFor: #friend!accessing!private! !
-!DetailedPerson2 categoriesFor: #friend:!accessing!private! !
-!DetailedPerson2 categoriesFor: #notes!accessing!private! !
-!DetailedPerson2 categoriesFor: #notes:!accessing!private! !
+!DetailedPerson2 categoriesForMethods!
+bestFriend!accessing!private! !
+bestFriend:!accessing!private! !
+dateOfBirth!accessing!private! !
+dateOfBirth:!accessing!private! !
+dob!accessing!private! !
+dob:!accessing!private! !
+friend!accessing!private! !
+friend:!accessing!private! !
+notes!accessing!private! !
+notes:!accessing!private! !
+!
 
 !DetailedPerson2 class methodsFor!
 
@@ -97,12 +99,14 @@ useLongNotes
 
 useLongNotes: anObject
 	useLongNotes := anObject! !
-!DetailedPerson2 class categoriesFor: #notesSize!accessing!private! !
-!DetailedPerson2 class categoriesFor: #reStoreDefinition!public! !
-!DetailedPerson2 class categoriesFor: #useBestFriend!public! !
-!DetailedPerson2 class categoriesFor: #useBestFriend:!public! !
-!DetailedPerson2 class categoriesFor: #useDateOfBirth!accessing!private! !
-!DetailedPerson2 class categoriesFor: #useDateOfBirth:!accessing!private! !
-!DetailedPerson2 class categoriesFor: #useLongNotes!accessing!private! !
-!DetailedPerson2 class categoriesFor: #useLongNotes:!accessing!private! !
+!DetailedPerson2 class categoriesForMethods!
+notesSize!accessing!private! !
+reStoreDefinition!public! !
+useBestFriend!public! !
+useBestFriend:!public! !
+useDateOfBirth!accessing!private! !
+useDateOfBirth:!accessing!private! !
+useLongNotes!accessing!private! !
+useLongNotes:!accessing!private! !
+!
 

--- a/ReStore/MidPerson.cls
+++ b/ReStore/MidPerson.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 SuperPerson subclass: #MidPerson
-	instanceVariableNames: 'middleName midFriend'
+	instanceVariableNames: 'middleName midFriend midFlags'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -12,29 +12,46 @@ https://github.com/rko281/ReStore'!
 !MidPerson categoriesForClass!Unclassified! !
 !MidPerson methodsFor!
 
+initialize
+	super initialize.
+	midFlags := TestBitmask new.!
+
 middleName
 	^middleName!
 
 middleName: anObject
 	middleName := anObject!
 
+midFlags
+	^midFlags.!
+
 midFriend
 	^midFriend!
 
 midFriend: anObject
 	midFriend := anObject! !
-!MidPerson categoriesFor: #middleName!accessing!private! !
-!MidPerson categoriesFor: #middleName:!accessing!private! !
-!MidPerson categoriesFor: #midFriend!accessing!private! !
-!MidPerson categoriesFor: #midFriend:!accessing!private! !
+!MidPerson categoriesForMethods!
+initialize!initializing!private! !
+middleName!accessing!private! !
+middleName:!accessing!private! !
+midFlags!accessing!private! !
+midFriend!accessing!private! !
+midFriend:!accessing!private! !
+!
 
 !MidPerson class methodsFor!
 
-reStoreDefinition
+mutableAspects
+	^super mutableAspects copyWith: #midFlags.!
 
+reStoreDefinition
 	^super reStoreDefinition
 		define: #middleName as: (String maxSize: 128);
 		define: #midFriend as: SuperPerson;
-		yourself! !
-!MidPerson class categoriesFor: #reStoreDefinition!public! !
+		define: #midFlags as: TestBitmask;
+		yourself.! !
+!MidPerson class categoriesForMethods!
+mutableAspects!constants!public! !
+reStoreDefinition!public! !
+!
 

--- a/ReStore/SSW ReStore Tables.pax
+++ b/ReStore/SSW ReStore Tables.pax
@@ -5,6 +5,8 @@ package paxVersion: 1;
 ©2019 John Aspinall
 https://github.com/rko281/ReStore'.
 
+package basicPackageVersion: '2.11'.
+
 
 package classNames
 	add: #SSWAccessor;

--- a/ReStore/SSW ReStore Tests.pax
+++ b/ReStore/SSW ReStore Tests.pax
@@ -279,7 +279,7 @@ Object subclass: #SimpleProductOrder
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 Object subclass: #SuperPerson
-	instanceVariableNames: 'surname firstName'
+	instanceVariableNames: 'surname firstName superFlags'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -339,12 +339,12 @@ SuperPerson subclass: #DetailedPerson2
 	poolDictionaries: ''
 	classInstanceVariableNames: 'useDateOfBirth useBestFriend useLongNotes'!
 SuperPerson subclass: #MidPerson
-	instanceVariableNames: 'middleName midFriend'
+	instanceVariableNames: 'middleName midFriend midFlags'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
 MidPerson subclass: #SubPerson
-	instanceVariableNames: 'age'
+	instanceVariableNames: 'age subFlags'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!

--- a/ReStore/SSWDBAbstractSubTable.cls
+++ b/ReStore/SSWDBAbstractSubTable.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smallalk"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 SSWDBInheritedTable subclass: #SSWDBAbstractSubTable
 	instanceVariableNames: 'rootClass classCondition'
@@ -43,14 +43,6 @@ hasStaticConditions
 isRootTable
 
 	^false!
-
-recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy
-	
-	"Set the class of the proxy to the actual class of object, since this may be one of the receiver's instanceClass' subclasses"
-	
-	super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy.
-	
-	anSSWDBObjectProxy _class: anSSWDBObjectProxy _proxiedObject class!
 
 registerClass
 
@@ -97,7 +89,6 @@ defaultName!evaluating!public! !
 forCreation!evaluating!public! !
 hasStaticConditions!public!testing! !
 isRootTable!public!testing! !
-recoverInstanceFromRow:into:!instance creation!public! !
 registerClass!evaluating!public! !
 rootClass!accessing!public! !
 rootClass:!accessing!public! !

--- a/ReStore/SSWDBInheritedTable.cls
+++ b/ReStore/SSWDBInheritedTable.cls
@@ -51,6 +51,30 @@ instanceClassFromRow: aDBRow
 	
 	^self classField convertValue: (aDBRow lookupField: self classField)!
 
+recoverExactClassInstanceFromRow: aDBRow into: anSSWDBObjectProxy
+	"Private - Recover assuming that aDBRow represents an object of exactly our instanceClass.
+	Class has already been set on the proxy (see #recoverInstanceFromRow:into:"
+
+	super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy.!
+
+recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy
+	"Redirect to the relevant concrete class, ensuring the proxy is informed of the actual class of the object.
+	We must do this before setting the proxiedObject to ensure that the correct list of fields is used when
+	initializing the copyObject.
+
+	N.B. This should always be our instanceClass or a subclass thereof, never higher in the hierarchy.
+	For leaf tables this means it should always be exactly our instanceClass, but this shared implementation is simpler."
+
+	| class |
+	class := self instanceClassFromRow: aDBRow.
+	self assert: (class includesBehavior: self instanceClass)
+		description: 
+			['Proxy for ' , self instanceClass name , ' retrieved a ' , class name , ' from the database.'].
+	anSSWDBObjectProxy _class: class.
+	(class = self instanceClass ifTrue: [self] ifFalse: [self reStore tableForClass: class])
+		recoverExactClassInstanceFromRow: aDBRow
+		into: anSSWDBObjectProxy.!
+
 setDefaultClassField
 	
 	self controlFields add: (self initializeClassField: SSWDBStaticField new).
@@ -75,11 +99,15 @@ withAllFields
 				[withAllFields dataFields add: field]]].
 	
 	^withAllFields! !
-!SSWDBInheritedTable categoriesFor: #classField!accessing!public! !
-!SSWDBInheritedTable categoriesFor: #classField:!accessing!public! !
-!SSWDBInheritedTable categoriesFor: #initializeClassField:!defining!private! !
-!SSWDBInheritedTable categoriesFor: #initializeIn:!initializing!public! !
-!SSWDBInheritedTable categoriesFor: #instanceClassFromRow:!instance creation!private! !
-!SSWDBInheritedTable categoriesFor: #setDefaultClassField!defining!public! !
-!SSWDBInheritedTable categoriesFor: #withAllFields!evaluating!public! !
+!SSWDBInheritedTable categoriesForMethods!
+classField!accessing!public! !
+classField:!accessing!public! !
+initializeClassField:!defining!private! !
+initializeIn:!initializing!public! !
+instanceClassFromRow:!instance creation!private! !
+recoverExactClassInstanceFromRow:into:!private! !
+recoverInstanceFromRow:into:!public! !
+setDefaultClassField!defining!public! !
+withAllFields!evaluating!public! !
+!
 

--- a/ReStore/SSWDBIntermediateTable.cls
+++ b/ReStore/SSWDBIntermediateTable.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smallalk"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 SSWDBAbstractSubTable subclass: #SSWDBIntermediateTable
 	instanceVariableNames: ''
@@ -25,18 +25,6 @@ _classCondition
 
 	^conditions!
 
-recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy
-	
-	"Redirect to the relevant concrete class"
-	
-	| class |
-	
-	class := self instanceClassFromRow: aDBRow.
-
-	class = self instanceClass
-		ifTrue: [super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy]
-		ifFalse: [(self reStore tableForClass: class) recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy]!
-
 subclasses
 
 	"Return those classes which inherit persistency from the receiver"
@@ -46,7 +34,6 @@ subclasses
 		(self reStore tableForClass: each) ifNil: [false] ifNotNil: [ :table | table rootClass = self rootClass]]! !
 !SSWDBIntermediateTable categoriesForMethods!
 _classCondition!evaluating!private! !
-recoverInstanceFromRow:into:!instance creation!public! !
 subclasses!evaluating!public! !
 !
 

--- a/ReStore/SSWDBSuperTable.cls
+++ b/ReStore/SSWDBSuperTable.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smallalk"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 SSWDBInheritedTable subclass: #SSWDBSuperTable
 	instanceVariableNames: ''
@@ -49,22 +49,6 @@ forCreation
 	
 	^tableForCreation!
 
-recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy
-	
-	"Redirect to the relevant concrete class. Also set the class of the proxy to the actual class of object.
-	(since this may be one of the receiver's instanceClass' subclasses)"
-	
-	| class |
-	
-	class := self instanceClassFromRow: aDBRow.
-
-	class = self instanceClass
-		ifTrue: [super recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy]
-		ifFalse: [(self reStore tableForClass: class) 
-				recoverInstanceFromRow: aDBRow into: anSSWDBObjectProxy].
-	
-	anSSWDBObjectProxy _class: anSSWDBObjectProxy _proxiedObject class!
-
 refreshProxy: aProxy whereChangedFromRow: aDBRow
 
 	"Redirect to the relevant concrete class"
@@ -78,7 +62,6 @@ refreshProxy: aProxy whereChangedFromRow: aDBRow
 		ifFalse: [(self reStore tableForClass: class) refreshProxy: aProxy whereChangedFromRow: aDBRow]! !
 !SSWDBSuperTable categoriesForMethods!
 forCreation!evaluating!public! !
-recoverInstanceFromRow:into:!instance creation!public! !
 refreshProxy:whereChangedFromRow:!instance creation!public! !
 !
 

--- a/ReStore/SSWReStoreHierarchyTest.cls
+++ b/ReStore/SSWReStoreHierarchyTest.cls
@@ -1,4 +1,4 @@
-﻿"Filed out from Dolphin Smallalk"!
+﻿"Filed out from Dolphin Smalltalk 7"!
 
 SSWReStoreTest subclass: #SSWReStoreHierarchyTest
 	instanceVariableNames: ''
@@ -13,39 +13,52 @@ https://github.com/rko281/ReStore'!
 !SSWReStoreHierarchyTest methodsFor!
 
 _testClassOfProxyOfIndirectInstanceOf: aClass
+	"Verify that, even when recovered via a second path, and without specifying the class as part of the retrieval,
+	the class of the proxy of an object from a persistent hierarchy is set correctly (previously not the case for leaf classes)"
 
-	"Verify that, even when recovered via a second path, the class of the proxy of an object from a persistent hierarchy is set correctly (previously not the case for leaf classes)"
-
-	self _testClassOfProxyOfInstanceOf: aClass recoveredBy: [ :proxy | (reStore instancesOf: aClass) asOrderedCollection collect: [ :each | each firstName]]!
+	self _testClassOfProxyOfInstanceOf: aClass
+		recoveredBy: [:proxy | (reStore instancesOf: SuperPerson) asOrderedCollection collect: [:each | each firstName]].!
 
 _testClassOfProxyOfInstanceOf: aClass
 
 	self _testClassOfProxyOfInstanceOf: aClass recoveredBy: [ :proxy | proxy firstName]!
 
 _testClassOfProxyOfInstanceOf: aClass recoveredBy: aBlock
+	"Verify that, when recovered using aBlock after initially being an unrecovered proxy,
+	the class of the proxy of an object from a persistent hierarchy is set correctly.
+	Also verify that any mutable fields have been correctly copied and change-detection functions correctly."
 
-	"Verify that, when recovered using aBlock after initially being an unrecovered proxy, the class of the proxy of an object from a persistent hierarchy is set correctly"
-
-	| owner |
-
+	| owner proxy |
 	"Just using MidPerson here for its reference to SuperPerson in its midFriend inst var"
 	owner := MidPerson new firstName: 'owner'.
-	owner midFriend: ((aClass storedInstancesIn: reStore) first).
+	owner midFriend: (aClass storedInstancesIn: reStore) first.
 	owner storeIn: reStore.
-
 	reStore simulateReconnect.
 
 	"Read the owner; at this stage midFriend will just be an unrecovered proxy"
-	owner := (MidPerson storedInstancesIn: reStore) detect: [ :each | each firstName = 'owner'].
+	owner := (MidPerson storedInstancesIn: reStore) detect: [:each | each firstName = 'owner'].
 	self assert: owner midFriend isDBProxy.
 	self assert: owner midFriend _proxiedObject isNil.
-	self assert: owner midFriend _class equals: SuperPerson. "at this stage - proxied object has not been read"
+	self assert: owner midFriend _class equals: SuperPerson.	"at this stage - proxied object has not been read"
 
 	"Recover it"
 	aBlock value: owner midFriend.
 	self deny: owner midFriend isDBProxy.
 	self assert: owner midFriend class equals: aClass.
-	self assert: (owner midFriend _dbProxyIn: reStore) _class equals: aClass!
+	proxy := owner midFriend _dbProxyIn: reStore.
+	self assert: proxy _class equals: aClass.
+
+	"Check that all declared mutable properties have been properly copied"
+	aClass mutableAspects withIndexDo: 
+			[:sym :i |
+			self deny: (proxy _proxiedObject perform: sym) == (proxy _copyObject perform: sym).
+			self deny: ((owner midFriend perform: sym) isBitSet: i).	"Sanity check, bitmask initializes with 0"
+			(owner midFriend perform: sym) bitSet: i].
+	owner midFriend storeIn: reStore.
+	reStore simulateReconnect.
+	owner := (MidPerson storedInstancesIn: reStore) detect: [:each | each firstName = 'owner'].
+	aClass mutableAspects
+		withIndexDo: [:sym :i | self assert: ((owner midFriend perform: sym) isBitSet: i)].!
 
 addClassesTo: aReStore
 
@@ -173,29 +186,6 @@ testClassOfProxyOfIndirectSuperInstance
 
 	self _testClassOfProxyOfIndirectInstanceOf: SuperPerson!
 
-testClassOfProxyOfInstanceOf: aClass
-
-	| owner |
-
-	"Just using MidPerson here for its reference to SuperPerson in its midFriend inst var"
-	owner := MidPerson new firstName: 'owner'.
-	owner midFriend: ((aClass storedInstancesIn: reStore) first).
-	owner storeIn: reStore.
-
-	reStore simulateReconnect.
-
-	"Read the owner; at this stage midFriend will just be an unrecovered proxy"
-	owner := (MidPerson storedInstancesIn: reStore) detect: [ :each | each firstName = 'owner'].
-	self assert: owner midFriend isDBProxy.
-	self assert: owner midFriend _proxiedObject isNil.
-	self assert: owner midFriend _class equals: SuperPerson. "at this stage - proxied object has not been read"
-
-	"Read via its own class"
-	(reStore instancesOf: aClass) asOrderedCollection collect: [ :each | each firstName].
-	self deny: owner midFriend isDBProxy.
-	self assert: owner midFriend class equals: aClass.
-	self assert: (owner midFriend _dbProxyIn: reStore) _class equals: aClass!
-
 testClassOfProxyOfMidInstance
 
 	self _testClassOfProxyOfInstanceOf: MidPerson!
@@ -296,7 +286,17 @@ testInheritanceStructureWithoutIntermediateInheritancePersistentIntermediateOldF
 		[AbstractB class methodDictionary
 			removeKey: #shouldSubclassesInheritPersistency;
 			removeKey: #addClassDefinitionTo:.
-		AbstractB class flushMethodCache]! !
+		AbstractB class flushMethodCache]!
+
+testRetrievingIncompatibleClassRaisesError
+	| detailedID midID |
+	midID := (reStore instancesOf: MidPerson) first _id.
+	detailedID := (DetailedPerson1 new storeIn: reStore) _id.
+	reStore simulateReconnect.
+	"Attempt to retrieve what is actually a DetailedPerson as if it were a MidPerson (siblings)"
+	self should: [(reStore deferredObjectOfClass: MidPerson withID: detailedID) firstName] raise: Error.
+	"As above, but parent of the declared class"
+	self should: [(reStore deferredObjectOfClass: SubPerson withID: midID) firstName] raise: Error.! !
 !SSWReStoreHierarchyTest categoriesForMethods!
 _testClassOfProxyOfIndirectInstanceOf:!private!unit tests! !
 _testClassOfProxyOfInstanceOf:!private!unit tests! !
@@ -312,7 +312,6 @@ test06SubFirst!public!unit tests! !
 testClassOfProxyOfIndirectMidInstance!public!unit tests! !
 testClassOfProxyOfIndirectSubInstance!public!unit tests! !
 testClassOfProxyOfIndirectSuperInstance!public!unit tests! !
-testClassOfProxyOfInstanceOf:!public!unit tests! !
 testClassOfProxyOfMidInstance!public!unit tests! !
 testClassOfProxyOfSubInstance!public!unit tests! !
 testClassOfProxyOfSuperInstance!public!unit tests! !
@@ -322,5 +321,6 @@ testInheritanceStructureWithoutInheritancePersistentIntermediate!public!unit tes
 testInheritanceStructureWithoutInheritancePersistentIntermediateOldFormat!public!unit tests! !
 testInheritanceStructureWithoutIntermediateInheritancePersistentIntermediate!public!unit tests! !
 testInheritanceStructureWithoutIntermediateInheritancePersistentIntermediateOldFormat!public!unit tests! !
+testRetrievingIncompatibleClassRaisesError!public!unit tests! !
 !
 

--- a/ReStore/SubPerson.cls
+++ b/ReStore/SubPerson.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 MidPerson subclass: #SubPerson
-	instanceVariableNames: 'age'
+	instanceVariableNames: 'age subFlags'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -16,16 +16,33 @@ age
 	^age!
 
 age: anObject
-	age := anObject! !
-!SubPerson categoriesFor: #age!accessing!private! !
-!SubPerson categoriesFor: #age:!accessing!private! !
+	age := anObject!
+
+initialize
+	super initialize.
+	subFlags := TestBitmask new.!
+
+subFlags
+	^subFlags.! !
+!SubPerson categoriesForMethods!
+age!accessing!private! !
+age:!accessing!private! !
+initialize!initializing!private! !
+subFlags!accessing!private! !
+!
 
 !SubPerson class methodsFor!
 
-reStoreDefinition
+mutableAspects
+	^super mutableAspects copyWith: #subFlags.!
 
+reStoreDefinition
 	^super reStoreDefinition
 		define: #age as: Integer;
-		yourself! !
-!SubPerson class categoriesFor: #reStoreDefinition!public! !
+		define: #subFlags as: TestBitmask;
+		yourself.! !
+!SubPerson class categoriesForMethods!
+mutableAspects!constants!public! !
+reStoreDefinition!public! !
+!
 

--- a/ReStore/SuperPerson.cls
+++ b/ReStore/SuperPerson.cls
@@ -1,7 +1,7 @@
 ﻿"Filed out from Dolphin Smalltalk 7"!
 
 Object subclass: #SuperPerson
-	instanceVariableNames: 'surname firstName'
+	instanceVariableNames: 'surname firstName superFlags'
 	classVariableNames: ''
 	poolDictionaries: ''
 	classInstanceVariableNames: ''!
@@ -24,6 +24,13 @@ fullName
 
 	^self firstName, ' ', self surname!
 
+initialize
+	super initialize.
+	superFlags := TestBitmask new.!
+
+superFlags
+	^superFlags.!
+
 surname
 
 	^surname!
@@ -31,19 +38,33 @@ surname
 surname: a
 
 	surname := a! !
-!SuperPerson categoriesFor: #firstName!public! !
-!SuperPerson categoriesFor: #firstName:!public! !
-!SuperPerson categoriesFor: #fullName!public! !
-!SuperPerson categoriesFor: #surname!public! !
-!SuperPerson categoriesFor: #surname:!public! !
+!SuperPerson categoriesForMethods!
+firstName!accessing!public! !
+firstName:!accessing!public! !
+fullName!accessing!public! !
+initialize!initializing!private! !
+superFlags!accessing!public! !
+surname!accessing!public! !
+surname:!accessing!public! !
+!
 
 !SuperPerson class methodsFor!
 
-reStoreDefinition
+mutableAspects
+	^#(#superFlags).!
 
+new
+	^self basicNew initialize.!
+
+reStoreDefinition
 	^super reStoreDefinition
 		define: #surname as: (String maxSize: 255);
 		define: #firstName as: (String maxSize: 255);
-		yourself! !
-!SuperPerson class categoriesFor: #reStoreDefinition!public! !
+		define: #superFlags as: TestBitmask;
+		yourself.! !
+!SuperPerson class categoriesForMethods!
+mutableAspects!constants!public! !
+new!instance creation!public! !
+reStoreDefinition!public! !
+!
 


### PR DESCRIPTION
Specifically occurs after fault-in through polymorphic reference whose declared class does not have that field.

Set the #_class: of the proxy *before* assigning the proxiedObject, so that #initializeCopyObject will operate on the full list of fields for the class of the object, even if the reference was declared using a superclass.

Also raise an error if the retrieved class does not #includesBehavior: the declared/expected class (e.g. accidentally requesting deferredObjectOfClass: SubPerson withID: <aMidPersonID>).