### PR TITLE
Fix tests broken by "swap exactly requested objects" change.

### DIFF
--- a/ReStore/SSWReStoreProxySwapperTest.cls
+++ b/ReStore/SSWReStoreProxySwapperTest.cls
@@ -400,7 +400,7 @@ testSwapCollectionsOnly
 
 testSwapObjectsAndCollections
 
-	"Test objects' collections are swapped even when not explicitly requested"
+	"Test objects' collections are swapped automatically when using SSWDBProxyAndCollectionsSwapper"
 
 	| orders sampleOrder product array ordered baseDictionary identityDictionary |
 
@@ -419,7 +419,7 @@ testSwapObjectsAndCollections
 	identityDictionary := ownerTest _proxiedObject keyedIdentityDictionary.
 	self assertAllUnswapped: {array. ordered. baseDictionary. identityDictionary}.
 
-	reStore swapAll: {customer1. product. ownerTest}.
+	reStore swapAll: {customer1. product. ownerTest} using: SSWDBProxyAndCollectionsSwapper.
 
 	self assertAllSwapped: {customer1. orders. product}.
 	self assertAllSwapped: {array. ordered. baseDictionary. identityDictionary}.
@@ -428,7 +428,7 @@ testSwapObjectsAndCollections
 
 testSwapObjectsAndCollectionsWithSwappedObject
 
-	"Test the customer's collections are swapped even when not explicitly requested and the customer is already swapped"
+	"Test the customer's collections are swapped on request even when the customer is already swapped"
 
 	| orders sampleOrder product |
 
@@ -440,8 +440,36 @@ testSwapObjectsAndCollectionsWithSwappedObject
 	product := sampleOrder _proxiedObject product.
 	self assertIsUnswapped: product.
 	
-	reStore swapAll: {customer1. product}.
+	reStore swapAll: {customer1. product} using: SSWDBProxyAndCollectionsSwapper.
 	self assertAllSwapped: {customer1. orders. product}.
+
+	self assertIsUnswapped: sampleOrder!
+
+testSwapObjectsOnly
+
+	"Test objects' collections are swapped only passed directly to swapper."
+
+	| orders sampleOrder product array ordered baseDictionary identityDictionary |
+
+	self assertIsUnswapped: customer1.
+	orders := customer1 _proxiedObject orders.
+	self assertIsUnswapped: orders.
+	sampleOrder := orders _proxiedObject anyOne.
+	self assertIsUnswapped: sampleOrder.
+	product := sampleOrder _proxiedObject product.
+	self assertIsUnswapped: product.
+
+	self assertIsUnswapped: ownerTest.
+	array := ownerTest _proxiedObject arrayOfNames.
+	ordered := ownerTest _proxiedObject ordered.
+	baseDictionary := ownerTest _proxiedObject keyedBaseDictionary.
+	identityDictionary := ownerTest _proxiedObject keyedIdentityDictionary.
+	self assertAllUnswapped: {array. ordered. baseDictionary. identityDictionary}.
+
+	reStore swapAll: {customer1. orders. product. ownerTest}.
+
+	self assertAllSwapped: {customer1. orders. product. ownerTest}.
+	self assertAllUnswapped: {array. ordered. baseDictionary. identityDictionary}.
 
 	self assertIsUnswapped: sampleOrder!
 
@@ -575,7 +603,7 @@ testUnswapCollectionsOnly
 
 testUnswapObjectsAndCollections
 
-	"Test the customer's collections are unswapped even when not explicitly requested"
+	"Test the customer's collections are unswapped when requested"
 
 	| orders sampleOrder product array ordered baseDictionary identityDictionary |
 
@@ -594,12 +622,39 @@ testUnswapObjectsAndCollections
 	baseDictionary anyOne.
 	identityDictionary anyOne.
 	self assertAllSwapped: {array. ordered. baseDictionary. identityDictionary}.
-	reStore unswapAll: {customer1. product. ownerTest}.
+	reStore unswapAll: {customer1. product. ownerTest} using: SSWDBProxyAndCollectionsSwapper.
 
 	self assertAllUnswapped: {customer1. orders. product}.
 	self assertAllUnswapped: {array. ordered. baseDictionary. identityDictionary}.
 
 	self assertIsSwapped: sampleOrder!
+
+testUnswapObjectsOnly
+
+	"Test the customer's collections are left swapped when the object is unswapped,
+	but can be explicitly requested."
+
+	| orders sampleOrder product array ordered baseDictionary identityDictionary |
+
+	orders := customer1 orders.
+	sampleOrder := orders first.
+	product := sampleOrder product.
+	product description.
+	self assertAllSwapped: {customer1. orders. sampleOrder. product}.
+
+	array := ownerTest arrayOfNames.
+	ordered := ownerTest ordered.
+	baseDictionary := ownerTest keyedBaseDictionary.
+	identityDictionary := ownerTest keyedIdentityDictionary.
+	array anyOne.
+	ordered anyOne.
+	baseDictionary anyOne.
+	identityDictionary anyOne.
+	self assertAllSwapped: {array. ordered. baseDictionary. identityDictionary}.
+	reStore unswapAll: {customer1. product. ownerTest. array} .
+
+	self assertAllUnswapped: {customer1. product. ownerTest. array}.
+	self assertAllSwapped: {sampleOrder. orders. ordered. baseDictionary. identityDictionary}.!
 
 testUnswapObjectsRecursively
 
@@ -681,12 +736,14 @@ testSwapAll!public!unit tests! !
 testSwapCollectionsOnly!public!unit tests! !
 testSwapObjectsAndCollections!public!unit tests! !
 testSwapObjectsAndCollectionsWithSwappedObject!public!unit tests! !
+testSwapObjectsOnly!public!unit tests! !
 testSwapObjectsRecoveredDuring!public!unit tests! !
 testSwapObjectsRecursively!public!unit tests! !
 testSwapObjectsRecursivelyWithIntermerdiateSwappedCollection!public!unit tests! !
 testSwapObjectsRecursivelyWithIntermerdiateSwappedObject!public!unit tests! !
 testUnswapCollectionsOnly!public!unit tests! !
 testUnswapObjectsAndCollections!public!unit tests! !
+testUnswapObjectsOnly!public!unit tests! !
 testUnswapObjectsRecursively!public!unit tests! !
 testUnswapObjectsRecursivelyWithIntermediateSwappedCollection!public!unit tests! !
 testUnswapObjectsRecursivelyWithIntermediateSwappedObject!public!unit tests! !


### PR DESCRIPTION
Keep existing tests but use SSWDBProxyAndCollectionsSwapper explicitly. Add #test[Un]SwapObjectsOnly covering the new default behavior.